### PR TITLE
Change the limits and requests block to argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,11 +104,11 @@ resource "kubernetes_deployment" "tfc_cloud_agent" {
             }
           }
           resources {
-            limits {
+            limits = {
               cpu    = var.resource_limits_cpu
               memory = var.resource_limits_memory
             }
-            requests {
+            requests = {
               cpu    = var.resource_requests_cpu
               memory = var.resource_requests_memory
             }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    kubernetes = ">= 1.12.0"
+    kubernetes = ">= 2.0.0"
   }
 }


### PR DESCRIPTION
## what
* Change the limits and requests block under the kubernetes_deployment resource to argument type.
* Proposing the change in the `main.tf` and the `versions.tf` together for consistency

## why
* Using this with the provider 2.61 and now getting this error

```
Error: Unsupported block type

  on main.tf line 107, in resource "kubernetes_deployment" "tfc_cloud_agent":
 107:             limits {

Blocks of type "limits" are not expected here. Did you mean to define argument
"limits"? If so, use the equals sign to assign it a value.


Error: Unsupported block type

  on main.tf line 111, in resource "kubernetes_deployment" "tfc_cloud_agent":
 111:             requests {

Blocks of type "requests" are not expected here. Did you mean to define
argument "requests"? If so, use the equals sign to assign it a value.
```

## references
* The change took place in v2.0.0 and onwards, https://registry.terraform.io/providers/hashicorp/kubernetes/2.0.0/docs/resources/deployment
